### PR TITLE
Compatibility test suite (part 6) - lookup package identifiers by URL API

### DIFF
--- a/Fixtures/CompatibilityTestSuite/gendata.json
+++ b/Fixtures/CompatibilityTestSuite/gendata.json
@@ -48,5 +48,8 @@
         "contentDispositionHeaderIsSet": true,
         "digestHeaderIsSet": true,
         "linkHeaderHasDuplicateRelations": false
+    },
+    "lookupPackageIdentifiers": {
+        "repositoryURLMetadataKey": "repositoryURL"
     }
 }

--- a/Fixtures/CompatibilityTestSuite/local-registry.json
+++ b/Fixtures/CompatibilityTestSuite/local-registry.json
@@ -98,5 +98,16 @@
         ],
         "contentDispositionHeaderIsSet": true,
         "digestHeaderIsSet": true
+    },
+    "lookupPackageIdentifiers": {
+        "urls": [
+            {
+                "url": "https://github.com/apple/swift-nio",
+                "packageIdentifiers": [ "apple.swift-nio" ]
+            }
+        ],
+        "unknownURLs": [
+            "https://github.com/unknown/unknown"
+        ]
     }
 }

--- a/Sources/PackageRegistryCompatibilityTestSuite/APITests/ListPackageReleases.swift
+++ b/Sources/PackageRegistryCompatibilityTestSuite/APITests/ListPackageReleases.swift
@@ -13,7 +13,6 @@
 import Foundation
 
 import AsyncHTTPClient
-import NIO
 
 final class ListPackageReleasesTests: APITest {
     let configuration: Configuration

--- a/Sources/PackageRegistryCompatibilityTestSuite/APITests/LookupPackageIdentifiers.swift
+++ b/Sources/PackageRegistryCompatibilityTestSuite/APITests/LookupPackageIdentifiers.swift
@@ -1,0 +1,108 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+import AsyncHTTPClient
+
+final class LookupPackageIdentifiersTests: APITest {
+    let configuration: Configuration
+
+    init(registryURL: String, authToken: AuthenticationToken?, apiVersion: String, configuration: Configuration, httpClient: HTTPClient) {
+        self.configuration = configuration
+        super.init(registryURL: registryURL, authToken: authToken, apiVersion: apiVersion, httpClient: httpClient)
+    }
+
+    func run() async {
+        for expectation in self.configuration.urls {
+            self.log.append(await self.run(lookupURL: expectation.url, expectation: expectation))
+            // Case-insensitivity
+            self.log.append(await self.run(lookupURL: expectation.url.flipcased, expectation: expectation))
+        }
+
+        for url in self.configuration.unknownURLs {
+            self.log.append(await TestCase(name: "Lookup package identifiers for unknown URL \(url)") { testCase in
+                let url = "\(self.registryURL)/identifiers?url=\(url)"
+
+                testCase.mark("HTTP request: GET \(url)")
+                let response = try await self.get(url: url, mediaType: .json)
+
+                // 4.4 Server should return 404 if URL is not recognized
+                testCase.mark("HTTP response status")
+                guard response.status == .notFound else {
+                    throw TestError("Expected HTTP status code 404 but got \(response.status.code)")
+                }
+
+                // 3.3 Server should communicate errors using "problem details" object
+                testCase.mark("Response body")
+                if response.body == nil {
+                    testCase.warning("Response should include problem details")
+                }
+            })
+        }
+
+        self.printLog()
+    }
+
+    private func run(lookupURL: String, expectation: Configuration.URLExpectation) async -> TestCase {
+        await TestCase(name: "Lookup package identifiers for URL \(lookupURL)") { testCase in
+            let url = "\(self.registryURL)/identifiers?url=\(lookupURL)"
+
+            testCase.mark("HTTP request: GET \(url)")
+            let response = try await self.get(url: url, mediaType: .json)
+
+            // 4.5 Server should return 200 if package identifiers are found
+            testCase.mark("HTTP response status")
+            guard response.status == .ok else {
+                throw TestError("Expected HTTP status code 200 but got \(response.status.code)")
+            }
+
+            // 3.5 Server must set "Content-Type" and "Content-Version" headers
+            self.checkContentTypeHeader(response.headers, expected: .json, for: &testCase)
+            self.checkContentVersionHeader(response.headers, for: &testCase)
+
+            testCase.mark("Parse response body")
+            guard let responseBody = response.body else {
+                throw TestError("Response body is empty")
+            }
+            guard let dictionary = try JSONSerialization.jsonObject(with: Data(buffer: responseBody), options: []) as? [String: Any] else {
+                throw TestError("Failed to decode response JSON")
+            }
+            guard let packageIdentifiers = dictionary["identifiers"] as? [String] else {
+                throw TestError("Response JSON does not have key \"identifiers\" or it is invalid")
+            }
+
+            testCase.mark("Package identifiers")
+            if Set(packageIdentifiers) != expectation.packageIdentifiers {
+                testCase.error("Expected package identifiers to be \(expectation.packageIdentifiers) but got \(packageIdentifiers)")
+            }
+        }
+    }
+}
+
+extension LookupPackageIdentifiersTests {
+    struct Configuration: Codable {
+        /// URLs to test
+        let urls: [URLExpectation]
+
+        /// URLs that are not recognized by the registry. i.e., the registry should return HTTP status code `404` for these.
+        let unknownURLs: Set<String>
+
+        struct URLExpectation: Codable {
+            /// Repository URL to query package identifiers for
+            let url: String
+
+            /// Expected package identifiers.
+            let packageIdentifiers: Set<String>
+        }
+    }
+}

--- a/Tests/PackageRegistryCompatibilityTestSuiteTests/AllCommandTests.swift
+++ b/Tests/PackageRegistryCompatibilityTestSuiteTests/AllCommandTests.swift
@@ -131,6 +131,15 @@ final class AllCommandTests: XCTestCase {
                 unknownSourceArchives: [PackageRelease(package: PackageIdentity(scope: unknownScope, name: "unknown"), version: "1.0.0")],
                 contentDispositionHeaderIsSet: true,
                 digestHeaderIsSet: true
+            ),
+            lookupPackageIdentifiers: LookupPackageIdentifiersTests.Configuration(
+                urls: [
+                    .init(
+                        url: "https://github.com/\(nioScope)/\(nioName)",
+                        packageIdentifiers: ["\(nioScope).\(nioName)"]
+                    ),
+                ],
+                unknownURLs: ["https://github.com/\(unknownScope)/unknown"]
             )
         )
         let configData = try JSONEncoder().encode(config)
@@ -145,6 +154,7 @@ final class AllCommandTests: XCTestCase {
             XCTAssert(stdout.contains("Fetch Package Release Information - All tests passed."))
             XCTAssert(stdout.contains("Fetch Package Release Manifest - All tests passed."))
             XCTAssert(stdout.contains("Download Source Archive - All tests passed."))
+            XCTAssert(stdout.contains("Lookup Package Identifiers - All tests passed."))
         }
     }
 
@@ -156,5 +166,6 @@ final class AllCommandTests: XCTestCase {
         XCTAssert(stdout.contains("Fetch Package Release Information - All tests passed."))
         XCTAssert(stdout.contains("Fetch Package Release Manifest - All tests passed."))
         XCTAssert(stdout.contains("Download Source Archive - All tests passed."))
+        XCTAssert(stdout.contains("Lookup Package Identifiers - All tests passed."))
     }
 }

--- a/Tests/PackageRegistryCompatibilityTestSuiteTests/FetchPackageReleaseInfoCommandTests.swift
+++ b/Tests/PackageRegistryCompatibilityTestSuiteTests/FetchPackageReleaseInfoCommandTests.swift
@@ -58,7 +58,7 @@ final class FetchPackageReleaseInfoCommandTests: XCTestCase {
                         packageRelease: PackageRelease(package: PackageIdentity(scope: scope, name: name), version: "1.14.2"),
                         resources: [.sourceArchive(checksum: "43c63aad4ff999ca48aff499d879ebf68ce3afc7d69dcabe2ae2b1033646e983")],
                         keyValues: [
-                            "repositoryURL": "https://github.com/\(scope)/swift-nio",
+                            "repositoryURL": "https://github.com/\(scope)/\(name)",
                             "commitHash": "8da5c5a",
                         ],
                         linkRelations: ["latest-version", "successor-version"]
@@ -67,7 +67,7 @@ final class FetchPackageReleaseInfoCommandTests: XCTestCase {
                         packageRelease: PackageRelease(package: PackageIdentity(scope: scope, name: name), version: "2.29.0"),
                         resources: [.sourceArchive(checksum: "f44ce7dcc5d4fadf95e9a95c0e4345d0ae25a203ec63460883e1ca771e0b347b")],
                         keyValues: [
-                            "repositoryURL": "https://github.com/\(scope)/swift-nio",
+                            "repositoryURL": "https://github.com/\(scope)/\(name)",
                             "commitHash": "d161bf6",
                         ],
                         linkRelations: ["latest-version", "successor-version", "predecessor-version"]
@@ -76,7 +76,7 @@ final class FetchPackageReleaseInfoCommandTests: XCTestCase {
                         packageRelease: PackageRelease(package: PackageIdentity(scope: scope, name: name), version: "2.30.0"),
                         resources: [.sourceArchive(checksum: "e9a5540d37bf4fa0b5d5a071b366eeca899b37ece4ce93b26cc14286d57fbcef")],
                         keyValues: [
-                            "repositoryURL": "https://github.com/\(scope)/swift-nio",
+                            "repositoryURL": "https://github.com/\(scope)/\(name)",
                             "commitHash": "d79e333",
                         ],
                         linkRelations: ["latest-version", "predecessor-version"]

--- a/Tests/PackageRegistryCompatibilityTestSuiteTests/LookupPackageIdentifiersCommandTests.swift
+++ b/Tests/PackageRegistryCompatibilityTestSuiteTests/LookupPackageIdentifiersCommandTests.swift
@@ -1,0 +1,89 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+import PackageRegistryClient
+@testable import PackageRegistryCompatibilityTestSuite
+import TSCBasic
+
+final class LookupPackageIdentifiersCommandTests: XCTestCase {
+    private var sourceArchives: [SourceArchiveMetadata]!
+    private var registryClient: PackageRegistryClient!
+
+    override func setUp() {
+        do {
+            let archivesJSON = self.fixtureURL(subdirectory: "SourceArchives", filename: "source_archives.json")
+            self.sourceArchives = try JSONDecoder().decode([SourceArchiveMetadata].self, from: Data(contentsOf: archivesJSON))
+        } catch {
+            XCTFail("Failed to load source_archives.json")
+        }
+
+        let clientConfiguration = PackageRegistryClient.Configuration(url: self.registryURL, defaultRequestTimeout: .seconds(1))
+        self.registryClient = PackageRegistryClient(httpClientProvider: .createNew, configuration: clientConfiguration)
+    }
+
+    override func tearDown() {
+        try! self.registryClient.syncShutdown()
+    }
+
+    func test_help() throws {
+        XCTAssert(try executeCommand(command: "package-registry-compatibility lookup-package-identifiers --help")
+            .stdout.contains("USAGE: package-registry-compatibility lookup-package-identifiers <url> <config-path>"))
+    }
+
+    func test_run() throws {
+        // Create package releases
+        let scope = "apple-\(UUID().uuidString.prefix(6))"
+        let nioName = "swift-nio"
+        let nioVersions = ["1.14.2", "2.29.0", "2.30.0"]
+        self.createPackageReleases(scope: scope, name: nioName, versions: nioVersions, client: self.registryClient, sourceArchives: self.sourceArchives)
+
+        let sdName = "swift-service-discovery"
+        let sdVersions = ["1.0.0"]
+        self.createPackageReleases(scope: scope, name: sdName, versions: sdVersions, client: self.registryClient, sourceArchives: self.sourceArchives)
+
+        let unknownScope = "test-\(UUID().uuidString.prefix(6))"
+
+        let config = PackageRegistryCompatibilityTestSuite.Configuration(
+            lookupPackageIdentifiers: LookupPackageIdentifiersTests.Configuration(
+                urls: [
+                    .init(
+                        url: "https://github.com/\(scope)/\(nioName)",
+                        packageIdentifiers: ["\(scope).\(nioName)"]
+                    ),
+                    .init(
+                        url: "https://github.com/\(scope)/\(sdName)",
+                        packageIdentifiers: ["\(scope).\(sdName)"]
+                    ),
+                ],
+                unknownURLs: ["https://github.com/\(unknownScope)/unknown"]
+            )
+        )
+        let configData = try JSONEncoder().encode(config)
+
+        try withTemporaryDirectory(removeTreeOnDeinit: true) { directoryPath in
+            let configPath = directoryPath.appending(component: "config.json")
+            try localFileSystem.writeFileContents(configPath, bytes: ByteString(Array(configData)))
+
+            XCTAssert(try self.executeCommand(subcommand: "lookup-package-identifiers", configPath: configPath.pathString, generateData: false)
+                .stdout.contains("Lookup Package Identifiers - All tests passed."))
+        }
+    }
+
+    func test_run_generateConfig() throws {
+        let configPath = self.fixturePath(filename: "gendata.json")
+        XCTAssert(try self.executeCommand(subcommand: "lookup-package-identifiers", configPath: configPath, generateData: true)
+            .stdout.contains("Lookup Package Identifiers - All tests passed."))
+    }
+}


### PR DESCRIPTION
Depends on https://github.com/apple/swift-package-registry-compatibility-test-suite/pull/11

`lookup-package-identifiers` subcommand (https://github.com/apple/swift-package-registry-compatibility-test-suite/commit/34392cd9f62af827c972ef4d4c23f835adc5840b)