### PR TITLE
Update fetch manifest API tests

### DIFF
--- a/Fixtures/CompatibilityTestSuite/gendata.json
+++ b/Fixtures/CompatibilityTestSuite/gendata.json
@@ -41,8 +41,7 @@
     },
     "fetchPackageReleaseManifest": {
         "contentLengthHeaderIsSet": true,
-        "contentDispositionHeaderIsSet": true,
-        "linkHeaderHasAlternateRelations": true
+        "contentDispositionHeaderIsSet": true
     },
     "downloadSourceArchive": {
         "contentDispositionHeaderIsSet": true,

--- a/Fixtures/CompatibilityTestSuite/local-registry.json
+++ b/Fixtures/CompatibilityTestSuite/local-registry.json
@@ -77,8 +77,7 @@
             }
         ],
         "contentLengthHeaderIsSet": true,
-        "contentDispositionHeaderIsSet": true,
-        "linkHeaderHasAlternateRelations": true
+        "contentDispositionHeaderIsSet": true
     },
     "downloadSourceArchive": {
         "sourceArchives": [

--- a/Sources/PackageRegistryCompatibilityTestSuite/APITests/FetchPackageReleaseManifest.swift
+++ b/Sources/PackageRegistryCompatibilityTestSuite/APITests/FetchPackageReleaseManifest.swift
@@ -90,7 +90,7 @@ final class FetchPackageReleaseManifestTests: APITest {
         await TestCase(name: "Fetch Package.swift for package release \(scope).\(name)@\(version)") { testCase in
             let url = "\(self.registryURL)/\(scope)/\(name)/\(version)/Package.swift"
 
-            let checkLinkAlternate = self.configuration.linkHeaderHasAlternateRelations && fixture.swiftVersions != nil
+            let checkLinkAlternate = fixture.swiftVersions != nil
             try await self.fetchAndCheckResponse(url: url, packageRelease: fixture.packageRelease, checkLinkAlternate: checkLinkAlternate,
                                                  expectedFilename: "Package.swift", for: &testCase)
         }
@@ -149,10 +149,6 @@ extension FetchPackageReleaseManifestTests {
 
         /// If `true`, the registry sets the "Content-Disposition" response header.
         let contentDispositionHeaderIsSet: Bool
-
-        /// If `true`, the registry should include "alternate" relations in the "Link" response header when fetching the
-        /// unqualified manifest (i.e., `Package.swift`), if the release has version-specific manifests.
-        let linkHeaderHasAlternateRelations: Bool
 
         struct PackageReleaseFixture: Codable {
             /// Package scope and name and release version

--- a/Sources/PackageRegistryCompatibilityTestSuite/README.md
+++ b/Sources/PackageRegistryCompatibilityTestSuite/README.md
@@ -360,7 +360,9 @@ The test configuration is a `fetchPackageReleaseManifest` JSON object with the f
 - `unknownPackageReleases`: An array of "package release" JSON objects for package releases that do not exist in the registry. In other words, the server is expected to return HTTP status code `404` for these.
 - `contentLengthHeaderIsSet`: If `true`, the `Content-Length` HTTP response header must be set.
 - `contentDispositionHeaderIsSet`: If `true`, the `Content-Disposition` HTTP response header must be set.
-- `linkHeaderHasAlternateRelations`: If `true`, the registry should include `alternate` relation(s) in the `Link` HTTP response header when fetching the unqualified manifest (i.e., `Package.swift`) and if the release has version-specific manifests.
+
+The registry must include `alternate` relation(s) in the `Link` HTTP response header when fetching the 
+unqualified manifest (i.e., `Package.swift`) and if the release has version-specific manifests.
 
 ###### Sample configuration
 
@@ -384,8 +386,7 @@ The test configuration is a `fetchPackageReleaseManifest` JSON object with the f
             }
         ],
         "contentLengthHeaderIsSet": true,
-        "contentDispositionHeaderIsSet": true,
-        "linkHeaderHasAlternateRelations": true
+        "contentDispositionHeaderIsSet": true
     }
 }
 ```
@@ -398,7 +399,9 @@ configuration when `--generate-data` flag is set.
 The `fetchPackageReleaseManifest` object is also required:
 - `contentLengthHeaderIsSet`: If `true`, the `Content-Length` HTTP response header must be set.
 - `contentDispositionHeaderIsSet`: If `true`, the `Content-Disposition` HTTP response header must be set.
-- `linkHeaderHasAlternateRelations`: If `true`, the registry should include `alternate` relation(s) in the `Link` HTTP response header when fetching the unqualified manifest (i.e., `Package.swift`) and if the release has version-specific manifests.
+
+The registry must include `alternate` relation(s) in the `Link` HTTP response header when fetching the 
+unqualified manifest (i.e., `Package.swift`) and if the release has version-specific manifests.
 
 The tool will use these configurations to construct the `fetchPackageReleaseManifest` configuration described in the previous section for testing.
 
@@ -408,8 +411,7 @@ The tool will use these configurations to construct the `fetchPackageReleaseMani
 {
     "fetchPackageReleaseManifest": {
         "contentLengthHeaderIsSet": true,
-        "contentDispositionHeaderIsSet": true,
-        "linkHeaderHasAlternateRelations": true
+        "contentDispositionHeaderIsSet": true
     }
 }
 ```
@@ -421,7 +423,7 @@ For each package release in `packageReleases`:
 2. Response status code must be `200`. Response must include `Content-Type` (`text/x-swift`) and `Content-Version` headers.
 3. If `contentLengthHeaderIsSet == true`, the response must include `Content-Length` header and response body length must match.
 4. If `contentDispositionHeaderIsSet == true`, the response must include `Content-Disposition` header and its value must contain `attachment; filename={filename}`.
-5. If `swiftVersions` is specified and `linkHeaderHasAlternateRelations == true`, then the `Link` response header must include `alternate` relation(s).
+5. If `swiftVersions` is specified, then the `Link` response header must include `alternate` relation(s).
 6. Response body must be non-empty.
 7. Repeat steps 1-6 with flipcased `scope` and `name` in the request URL to test for case-insensitivity.
 8. For each Swift version in `swiftVersions`:

--- a/Sources/PackageRegistryCompatibilityTestSuite/TestConfigurationGenerator.swift
+++ b/Sources/PackageRegistryCompatibilityTestSuite/TestConfigurationGenerator.swift
@@ -216,8 +216,7 @@ struct TestConfigurationGenerator {
                 .init(package: $0, version: "1.0.0")
             }),
             contentLengthHeaderIsSet: configuration.contentLengthHeaderIsSet,
-            contentDispositionHeaderIsSet: configuration.contentDispositionHeaderIsSet,
-            linkHeaderHasAlternateRelations: configuration.linkHeaderHasAlternateRelations
+            contentDispositionHeaderIsSet: configuration.contentDispositionHeaderIsSet
         )
     }
 
@@ -423,9 +422,6 @@ extension TestConfigurationGenerator {
 
             /// See `FetchPackageReleaseManifestTests.Configuration.contentDispositionHeaderIsSet`
             let contentDispositionHeaderIsSet: Bool
-
-            /// See `FetchPackageReleaseManifestTests.Configuration.linkHeaderHasAlternateRelations`
-            let linkHeaderHasAlternateRelations: Bool
         }
 
         struct DownloadSourceArchive: Codable {

--- a/Tests/PackageRegistryCompatibilityTestSuiteTests/AllCommandTests.swift
+++ b/Tests/PackageRegistryCompatibilityTestSuiteTests/AllCommandTests.swift
@@ -118,8 +118,7 @@ final class AllCommandTests: XCTestCase {
                 ],
                 unknownPackageReleases: [PackageRelease(package: PackageIdentity(scope: unknownScope, name: "unknown"), version: "1.0.0")],
                 contentLengthHeaderIsSet: true,
-                contentDispositionHeaderIsSet: true,
-                linkHeaderHasAlternateRelations: true
+                contentDispositionHeaderIsSet: true
             ),
             downloadSourceArchive: DownloadSourceArchiveTests.Configuration(
                 sourceArchives: [

--- a/Tests/PackageRegistryCompatibilityTestSuiteTests/FetchPackageReleaseManifestCommandTests.swift
+++ b/Tests/PackageRegistryCompatibilityTestSuiteTests/FetchPackageReleaseManifestCommandTests.swift
@@ -62,8 +62,7 @@ final class FetchPackageReleaseManifestCommandTests: XCTestCase {
                 ],
                 unknownPackageReleases: [PackageRelease(package: PackageIdentity(scope: unknownScope, name: "unknown"), version: "1.0.0")],
                 contentLengthHeaderIsSet: true,
-                contentDispositionHeaderIsSet: true,
-                linkHeaderHasAlternateRelations: true
+                contentDispositionHeaderIsSet: true
             )
         )
         let configData = try JSONEncoder().encode(config)


### PR DESCRIPTION
Motivation:
Per https://github.com/apple/swift-package-manager/pull/3896, `Link` is required in the response for `Package.swift` if a package has version-specific manifests.

Modifications:
Remove `linkHeaderHasAlternateRelations` option. The tests will check for presence of the `Link` header if `swiftVersions` is set.
